### PR TITLE
API version

### DIFF
--- a/language-service/CLU/EmailApp
+++ b/language-service/CLU/EmailApp
@@ -1,5 +1,5 @@
 {
-    "api-version": "2022-03-01-preview",
+    "api-version": "2022-05-01",
     "stringIndexType": "Utf16CodeUnit",
     "metadata": {
         "projectKind": "conversation",


### PR DESCRIPTION
@aahill - The [documentation](https://learn.microsoft.com/en-us/azure/cognitive-services/language-service/conversational-language-understanding/quickstart?pivots=rest-api#request-url) refers to `2022-05-01`. Should this JSON file be updated to match?